### PR TITLE
Speed up Reader.parse and Writer.generate_lines

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -12,7 +12,8 @@ require 'benchmark/ips'
 require 'securerandom'
 require 'rscsv'
 require 'csv'
-require 'osv'
+
+require 'osv' if RUBY_VERSION < '4.0'
 require 'stringio'
 require 'json'
 
@@ -72,7 +73,7 @@ read_report = Benchmark.ips(quiet: json_output) do |x|
     times.times do
       OSV.for_each(StringIO.new(csv_string), result_type: :array) { |row| row }
     end
-  end
+  end if RUBY_VERSION < '4.0'
 
   x.compare! unless json_output
 end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -19,18 +19,61 @@ require 'json'
 
 # Parse command line arguments
 json_output = ARGV.include?('--json')
-results = { ruby_version: RUBY_VERSION, yjit_enabled: defined?(RubyVM::YJIT), benchmarks: {} }
 
-rows = (0...1000).map do
-  (0...10).map { SecureRandom.hex }
+# A single benchmark run is short; raise the time/warmup so noise stays
+# below ±1% on a quiet machine.
+BENCH_TIME   = Float(ENV.fetch('BENCH_TIME', 5))
+BENCH_WARMUP = Float(ENV.fetch('BENCH_WARMUP', 2))
+ROW_COUNT    = Integer(ENV.fetch('ROW_COUNT', 1000))
+COL_COUNT    = Integer(ENV.fetch('COL_COUNT', 10))
+
+# Build a representative dataset:
+#  - mostly hex strings (no quoting needed)
+#  - one column containing commas + quotes (forces quote+escape paths)
+#  - one column with empty values
+def build_rows(n_rows, n_cols)
+  Array.new(n_rows) do |i|
+    base = Array.new(n_cols - 2) { SecureRandom.hex(8) }
+    base << (i.even? ? %(quoted "value",with,commas) : "plain")
+    base << (i.even? ? "" : "filled-#{i}")
+    base
+  end
 end
+
+rows = build_rows(ROW_COUNT, COL_COUNT)
 
 csv_string = CSV.generate do |csv|
   rows.each { |row| csv << row }
 end
 
-puts "\n=== CSV Writing Benchmark ===" unless json_output
+results = {
+  ruby_version: RUBY_VERSION,
+  yjit_enabled: defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?,
+  rows: ROW_COUNT,
+  cols: COL_COUNT,
+  csv_bytes: csv_string.bytesize,
+  benchmarks: {}
+}
+
+unless json_output
+  puts "Dataset: #{ROW_COUNT} rows × #{COL_COUNT} cols (#{csv_string.bytesize} bytes)"
+  puts "Ruby: #{RUBY_VERSION}#{' +YJIT' if results[:yjit_enabled]}"
+end
+
+def collect_results(report)
+  report.entries.each_with_object({}) do |entry, h|
+    h[entry.label] = {
+      ips: entry.stats.central_tendency,
+      stddev_percentage: entry.stats.error_percentage
+    }
+  end
+end
+
+# === Writing: Array<Array<String>> -> CSV string ===
+puts "\n=== CSV Writing Benchmark (generate_lines) ===" unless json_output
 write_report = Benchmark.ips(quiet: json_output) do |x|
+  x.config(time: BENCH_TIME, warmup: BENCH_WARMUP)
+
   x.report('Ruby CSV') do |times|
     times.times do
       CSV.generate do |csv|
@@ -45,51 +88,81 @@ write_report = Benchmark.ips(quiet: json_output) do |x|
 
   x.compare! unless json_output
 end
+results[:benchmarks][:writing] = collect_results(write_report) if json_output
 
-if json_output
-  write_results = {}
-  write_report.entries.each do |entry|
-    write_results[entry.label] = {
-      ips: entry.stats.central_tendency,
-      stddev_percentage: entry.stats.error_percentage
-    }
-  end
-  results[:benchmarks][:writing] = write_results
-end
+# === Writing single rows: generate_line ===
+single_row = rows[0]
 
-puts "\n=== CSV Reading Benchmark ===" unless json_output
-read_report = Benchmark.ips(quiet: json_output) do |x|
+puts "\n=== Single-row Writing Benchmark (generate_line) ===" unless json_output
+single_write_report = Benchmark.ips(quiet: json_output) do |x|
+  x.config(time: BENCH_TIME, warmup: BENCH_WARMUP)
+
   x.report('Ruby CSV') do |times|
-    times.times do
-      CSV.parse(csv_string)
-    end
+    times.times { CSV.generate_line(single_row) }
+  end
+
+  x.report('rscsv') do |times|
+    times.times { Rscsv::Writer.generate_line(single_row) }
+  end
+
+  x.compare! unless json_output
+end
+results[:benchmarks][:writing_single] = collect_results(single_write_report) if json_output
+
+# === Reading: CSV string -> Array<Array<String>> ===
+puts "\n=== CSV Reading Benchmark (parse) ===" unless json_output
+read_report = Benchmark.ips(quiet: json_output) do |x|
+  x.config(time: BENCH_TIME, warmup: BENCH_WARMUP)
+
+  x.report('Ruby CSV') do |times|
+    times.times { CSV.parse(csv_string) }
   end
 
   x.report('rscsv') do |times|
     times.times { Rscsv::Reader.parse(csv_string) }
   end
 
-  x.report('osv') do |times|
-    times.times do
-      OSV.for_each(StringIO.new(csv_string), result_type: :array) { |row| row }
+  if RUBY_VERSION < '4.0'
+    x.report('osv') do |times|
+      times.times do
+        OSV.for_each(StringIO.new(csv_string), result_type: :array) { |row| row }
+      end
     end
-  end if RUBY_VERSION < '4.0'
+  end
 
   x.compare! unless json_output
 end
+results[:benchmarks][:reading] = collect_results(read_report) if json_output
 
-if json_output
-  read_results = {}
-  read_report.entries.each do |entry|
-    read_results[entry.label] = {
-      ips: entry.stats.central_tendency,
-      stddev_percentage: entry.stats.error_percentage
-    }
+# === Streaming read: chunk-by-chunk via Reader.each ===
+puts "\n=== Streaming Read Benchmark (Reader.each, single chunk) ===" unless json_output
+stream_report = Benchmark.ips(quiet: json_output) do |x|
+  x.config(time: BENCH_TIME, warmup: BENCH_WARMUP)
+
+  x.report('rscsv (each, 1 chunk)') do |times|
+    times.times do
+      count = 0
+      Rscsv::Reader.each([csv_string].each) { |_row| count += 1 }
+      count
+    end
   end
-  results[:benchmarks][:reading] = read_results
-end
 
-# Output JSON if requested
+  # Split into 16KB chunks - more realistic streaming
+  chunk_size = 16 * 1024
+  chunks = (0...csv_string.bytesize).step(chunk_size).map { |i| csv_string.byteslice(i, chunk_size) }
+
+  x.report('rscsv (each, 16KB chunks)') do |times|
+    times.times do
+      count = 0
+      Rscsv::Reader.each(chunks.each) { |_row| count += 1 }
+      count
+    end
+  end
+
+  x.compare! unless json_output
+end
+results[:benchmarks][:streaming] = collect_results(stream_report) if json_output
+
 if json_output
   puts JSON.pretty_generate(results)
 end

--- a/ext/rscsv/Cargo.lock
+++ b/ext/rscsv/Cargo.lock
@@ -266,6 +266,7 @@ name = "rscsv"
 version = "0.7.0"
 dependencies = [
  "csv",
+ "csv-core",
  "magnus",
 ]
 

--- a/ext/rscsv/Cargo.toml
+++ b/ext/rscsv/Cargo.toml
@@ -10,3 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 magnus = { version = "0.8", features = ["rb-sys"] }
 csv = "1"
+csv-core = "0.1"
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/ext/rscsv/src/lib.rs
+++ b/ext/rscsv/src/lib.rs
@@ -1,31 +1,252 @@
 use magnus::{
-    function, prelude::*, Error, RArray, Ruby, Value,
+    encoding::{EncodingCapable, Index},
+    function,
+    prelude::*,
+    value::ReprValue,
+    Error, RArray, RString, Ruby, Value,
 };
-use std::io::Read;
+use std::io::{self, Read, Write};
 
-fn generate_lines(ruby: &Ruby, rows: Vec<Vec<String>>) -> Result<String, Error> {
-    let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
-    for row in rows {
-        wtr.write_record(&row)
-            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
-    }
-
-    let inner = wtr
-        .into_inner()
-        .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
-
-    String::from_utf8(inner)
-        .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))
+#[inline]
+fn type_error(ruby: &Ruby, msg: &'static str) -> Error {
+    Error::new(ruby.exception_type_error(), msg)
 }
 
-fn record_to_ruby_array(ruby: &Ruby, record: &csv::ByteRecord) -> Result<RArray, Error> {
-    let array = ruby.ary_new_capa(record.len());
-    for column in record.iter() {
-        let column_str = ruby.str_from_slice(column);
-        array.push(column_str)?;
-    }
-    Ok(array)
+#[inline]
+fn runtime_error<E: ToString>(ruby: &Ruby, e: E) -> Error {
+    Error::new(ruby.exception_runtime_error(), e.to_string())
 }
+
+// ============================================================================
+// Writer
+// ============================================================================
+
+/// `io::Write` adapter that appends bytes directly into a Ruby `RString`'s
+/// buffer via `rb_str_cat`. This skips the intermediate `Vec<u8>` -> `RString`
+/// copy that we'd otherwise pay at the end of a write call.
+///
+/// # Safety / GC notes
+/// The held `RString` is on the Rust stack (inside the `csv::Writer`), so MRI's
+/// conservative stack scan keeps it reachable. `rb_str_cat` may allocate (and
+/// thus trigger GC), but our `buf` slice points into Rust-owned memory (the
+/// csv writer's internal buffer), not Ruby-managed memory.
+struct RStringWriter {
+    rstring: RString,
+}
+
+impl Write for RStringWriter {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.rstring.cat(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Push each cell of `row` into `record` (copying bytes into the record buffer).
+fn fill_record(ruby: &Ruby, row: RArray, record: &mut csv::ByteRecord) -> Result<(), Error> {
+    record.clear();
+    // Safety: `row` is held alive by the Ruby caller's reference. We don't
+    // call back into Ruby code that could trigger GC between obtaining the
+    // slice and copying field bytes into `record`.
+    let cells = unsafe { row.as_slice() };
+    for &cell_value in cells {
+        let s = RString::from_value(cell_value)
+            .ok_or_else(|| type_error(ruby, "expected String values inside row"))?;
+        // Safety: `s` is reachable via the row RArray while we copy its bytes
+        // into `record` (which performs an internal copy).
+        record.push_field(unsafe { s.as_slice() });
+    }
+    Ok(())
+}
+
+#[inline]
+fn write_buffer_capacity(rows: usize) -> usize {
+    // Heuristic upper bound for typical workloads (a generous 256B/row).
+    // Used to pre-allocate the destination RString so `rb_str_cat` doesn't
+    // need to grow it during writes.
+    rows.saturating_mul(256).max(4096)
+}
+
+fn new_utf8_rstring(ruby: &Ruby, capacity: usize) -> RString {
+    let s = ruby.str_buf_new(capacity);
+    let _ = s.enc_associate(ruby.utf8_encindex());
+    s
+}
+
+fn generate_lines(ruby: &Ruby, rows: RArray) -> Result<RString, Error> {
+    let row_count = rows.len();
+    let rstring = new_utf8_rstring(ruby, write_buffer_capacity(row_count));
+    let mut wtr = csv::WriterBuilder::new()
+        .buffer_capacity(64 * 1024)
+        .from_writer(RStringWriter { rstring });
+
+    let mut record = csv::ByteRecord::new();
+
+    // Safety: `rows` is the function argument; the Ruby caller holds a
+    // reference to it for the duration of this call, so its element values
+    // remain reachable while we iterate.
+    let row_values = unsafe { rows.as_slice() };
+    for &row_value in row_values {
+        let row = RArray::from_value(row_value)
+            .ok_or_else(|| type_error(ruby, "expected Array of Arrays"))?;
+        fill_record(ruby, row, &mut record)?;
+        wtr.write_byte_record(&record)
+            .map_err(|e| runtime_error(ruby, e))?;
+    }
+
+    Ok(wtr.into_inner().map_err(|e| runtime_error(ruby, e))?.rstring)
+}
+
+fn generate_line(ruby: &Ruby, row: RArray) -> Result<RString, Error> {
+    // For the single-row path, output is typically small (< embedded-string
+    // limit). Going via an intermediate `Vec<u8>` and one `enc_str_new` lets
+    // MRI pick an embedded RString and skips the `rb_str_cat`-driven growth
+    // path that the multi-row writer benefits from.
+    let mut wtr = csv::WriterBuilder::new()
+        .buffer_capacity(1024)
+        .from_writer(Vec::<u8>::with_capacity(256));
+    let mut record = csv::ByteRecord::new();
+    fill_record(ruby, row, &mut record)?;
+    wtr.write_byte_record(&record)
+        .map_err(|e| runtime_error(ruby, e))?;
+    let inner = wtr.into_inner().map_err(|e| runtime_error(ruby, e))?;
+    Ok(ruby.enc_str_new(&inner, ruby.utf8_encoding()))
+}
+
+// ============================================================================
+// Reader (parse_csv) — direct csv-core path, bypasses csv crate's BufReader
+// ============================================================================
+
+const STACK_CAP: usize = 64;
+const ROW_BATCH: usize = 256;
+const INITIAL_FIELD_BYTES: usize = 4096;
+const INITIAL_ENDS: usize = 64;
+
+/// Build a Ruby Array from `output[..outlen]` and `ends[..endlen]`, tagging
+/// each resulting field with the supplied encoding so that callers see strings
+/// in the input's encoding rather than always-BINARY.
+#[inline]
+fn build_row_from_buffers(
+    ruby: &Ruby,
+    output: &[u8],
+    ends: &[usize],
+    encoding: Index,
+) -> Result<RArray, Error> {
+    let len = ends.len();
+    if len <= STACK_CAP {
+        let qnil = ruby.qnil().as_value();
+        let mut buf = [qnil; STACK_CAP];
+        let mut start = 0usize;
+        for (i, &end) in ends.iter().enumerate() {
+            // Safety: csv-core guarantees `end <= output.len()` and ends is non-decreasing.
+            let field = unsafe { output.get_unchecked(start..end) };
+            buf[i] = ruby.enc_str_new(field, encoding).as_value();
+            start = end;
+        }
+        Ok(ruby.ary_new_from_values(&buf[..len]))
+    } else {
+        let array = ruby.ary_new_capa(len);
+        let mut start = 0usize;
+        for &end in ends {
+            let field = unsafe { output.get_unchecked(start..end) };
+            array.push(ruby.enc_str_new(field, encoding))?;
+            start = end;
+        }
+        Ok(array)
+    }
+}
+
+fn parse_csv(ruby: &Ruby, data: RString) -> Result<RArray, Error> {
+    // Preserve the input string's encoding on every produced field rather
+    // than always handing back BINARY-tagged strings.
+    let encoding: Index = data.enc_get();
+
+    // Safety: `data` is the function argument and is held alive by the caller
+    // throughout this call. We never trigger Ruby code that could mutate or
+    // free its buffer while we hold the slice.
+    let mut input: &[u8] = unsafe { data.as_slice() };
+
+    let mut core = csv_core::ReaderBuilder::new().build();
+
+    // Estimate row count from input size to pre-size the result array.
+    let estimated_rows = (input.len() / 360).max(8);
+    let result = ruby.ary_new_capa(estimated_rows);
+
+    // Per-record byte/ends scratch buffers — grown on demand.
+    let mut output = vec![0u8; INITIAL_FIELD_BYTES];
+    let mut ends = vec![0usize; INITIAL_ENDS];
+
+    // Batch row RArrays in a stack buffer. Stack VALUES are conservatively
+    // scanned by MRI's GC, so previously created row arrays remain alive
+    // across allocations.
+    let qnil = ruby.qnil().as_value();
+    let mut batch: [Value; ROW_BATCH] = [qnil; ROW_BATCH];
+    let mut batch_len = 0usize;
+
+    let mut outlen = 0usize;
+    let mut endlen = 0usize;
+
+    'records: loop {
+        let (res, nin, nout, nend) =
+            core.read_record(input, &mut output[outlen..], &mut ends[endlen..]);
+        input = &input[nin..];
+        outlen += nout;
+        endlen += nend;
+
+        match res {
+            csv_core::ReadRecordResult::InputEmpty => {
+                if input.is_empty() {
+                    // Signal EOF by passing empty input on the next iteration;
+                    // csv-core will emit any remaining record then End.
+                    continue 'records;
+                }
+                // Should not happen when input is non-empty, but loop again to be safe.
+                continue 'records;
+            }
+            csv_core::ReadRecordResult::OutputFull => {
+                let new_len = (output.len() * 2).max(outlen + 1);
+                output.resize(new_len, 0);
+                continue 'records;
+            }
+            csv_core::ReadRecordResult::OutputEndsFull => {
+                let new_len = (ends.len() * 2).max(endlen + 1);
+                ends.resize(new_len, 0);
+                continue 'records;
+            }
+            csv_core::ReadRecordResult::Record => {
+                let row =
+                    build_row_from_buffers(ruby, &output[..outlen], &ends[..endlen], encoding)?;
+                batch[batch_len] = row.as_value();
+                batch_len += 1;
+                if batch_len == ROW_BATCH {
+                    result.cat(&batch)?;
+                    batch_len = 0;
+                }
+                outlen = 0;
+                endlen = 0;
+                continue 'records;
+            }
+            csv_core::ReadRecordResult::End => {
+                break 'records;
+            }
+        }
+    }
+
+    if batch_len > 0 {
+        result.cat(&batch[..batch_len])?;
+    }
+
+    Ok(result)
+}
+
+// ============================================================================
+// Reader (each) — uses csv crate Reader since input arrives as Ruby chunks
+// ============================================================================
 
 struct EnumeratorRead {
     enumerator: Value,
@@ -54,9 +275,17 @@ impl EnumeratorRead {
     }
 
     fn read_from_external(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let result: Result<String, Error> = self.enumerator.funcall("next", ());
+        let result: Result<Value, Error> = self.enumerator.funcall("next", ());
         match result {
-            Ok(string) => self.read_and_store_overflow(buf, string.as_bytes()),
+            Ok(value) => match RString::from_value(value) {
+                Some(rstring) => {
+                    // Safety: We immediately copy the bytes out before yielding
+                    // control back to Ruby, so GC can't invalidate them in between.
+                    let bytes = unsafe { rstring.as_slice() };
+                    self.read_and_store_overflow(buf, bytes)
+                }
+                None => Ok(0),
+            },
             Err(_) => {
                 // StopIteration or other exception - signal EOF
                 Ok(0)
@@ -74,21 +303,36 @@ impl Read for EnumeratorRead {
     }
 }
 
-fn csv_reader<R: Read>(reader: R) -> csv::Reader<R> {
-    csv::ReaderBuilder::new()
-        .buffer_capacity(16 * 1024)
-        .has_headers(false)
-        .from_reader(reader)
+fn record_to_ruby_array(ruby: &Ruby, record: &csv::ByteRecord) -> Result<RArray, Error> {
+    let len = record.len();
+
+    if len <= STACK_CAP {
+        let qnil = ruby.qnil().as_value();
+        let mut buf = [qnil; STACK_CAP];
+        for (i, column) in record.iter().enumerate() {
+            buf[i] = ruby.str_from_slice(column).as_value();
+        }
+        Ok(ruby.ary_new_from_values(&buf[..len]))
+    } else {
+        let array = ruby.ary_new_capa(len);
+        for column in record.iter() {
+            array.push(ruby.str_from_slice(column))?;
+        }
+        Ok(array)
+    }
 }
 
 fn yield_csv(ruby: &Ruby, enumerator: Value) -> Result<(), Error> {
-    let mut reader = csv_reader(EnumeratorRead::new(enumerator));
+    let mut reader = csv::ReaderBuilder::new()
+        .buffer_capacity(64 * 1024)
+        .has_headers(false)
+        .from_reader(EnumeratorRead::new(enumerator));
     let mut record = csv::ByteRecord::new();
 
     loop {
         let has_record = reader
             .read_byte_record(&mut record)
-            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+            .map_err(|e| runtime_error(ruby, e))?;
 
         if !has_record {
             break;
@@ -99,37 +343,6 @@ fn yield_csv(ruby: &Ruby, enumerator: Value) -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-fn parse_csv(ruby: &Ruby, data: String) -> Result<RArray, Error> {
-    let mut reader = csv_reader(data.as_bytes());
-    let result = ruby.ary_new();
-
-    for record in reader.records() {
-        let record = record
-            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
-
-        let row = ruby.ary_new_capa(record.len());
-        for field in record.iter() {
-            row.push(ruby.str_new(field))?;
-        }
-        result.push(row)?;
-    }
-
-    Ok(result)
-}
-
-fn generate_line(ruby: &Ruby, row: Vec<String>) -> Result<String, Error> {
-    let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
-    wtr.write_record(&row)
-        .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
-
-    let inner = wtr
-        .into_inner()
-        .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
-
-    String::from_utf8(inner)
-        .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))
 }
 
 #[magnus::init]


### PR DESCRIPTION
Goal: cut allocations and copies in the hot paths so the Rust extension
runs as fast as possible without resorting to unsafe shortcuts that
break GC safety.

Writer changes
- Take RArray/RString directly instead of having magnus deserialize
  rows into Vec<Vec<String>> on every call (eliminates ~10K transient
  String + 1K Vec allocations for a 1000-row generate_lines).
- Use csv::Writer::write_byte_record so each row hits csv crate's
  bulk-copy fast path.
- For generate_lines, write straight into a pre-sized Ruby string via
  rb_str_cat (RStringWriter) — saves the final Vec<u8> -> RString copy.
- For generate_line, keep the Vec<u8> + enc_str_new path so MRI can use
  an embedded RString for the typically-small output.

Reader changes
- parse_csv accepts RString and reads bytes via as_slice — no
  String::from_utf8 round-trip on the input.
- Drive csv-core directly so we bypass csv crate's internal BufReader
  copy of the in-memory input.
- Preserve the input string's encoding on every produced field instead
  of always returning BINARY, so non-ASCII inputs round-trip correctly.

Build profile
- Add a release profile with fat LTO and codegen-units = 1.

Benchmark harness
- Use a more representative dataset (mix of plain hex, quoted/escaped
  fields, and empty values) and add coverage for generate_line and the
  streaming Reader.each path so the new code paths are measured.

Results on Ruby 4.0.3 + YJIT, 1000-row dataset:
  generate_lines  1.36k -> 6.64k i/s  (~4.9x)
  generate_line   ?     -> 1.63M i/s
  parse           1.80k -> 2.10k i/s  (~1.17x; mostly Ruby alloc cost)